### PR TITLE
Un-hardcode python path

### DIFF
--- a/faust2sc.py
+++ b/faust2sc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # Compile a faust file as a SuperCollider help file
 import os
 import sys


### PR DESCRIPTION
Use /usr/bin/env to get python path, also enforcing use of python3. 